### PR TITLE
fix: Vim:E715: Dictionary required (#5)

### DIFF
--- a/lua/bookmark/config.lua
+++ b/lua/bookmark/config.lua
@@ -8,12 +8,11 @@ local defaults = {
 	file_highlight = "Function",
 }
 
-
 vim.fn.sign_define("FilemarkSign", { text = "󱡅", texthl = "Debug" })
 function M.setup(options)
 	M.options = vim.tbl_deep_extend("force", defaults, options or {})
-	vim.fn.sign_define("BookmarkSign", { text = options.sign, texthl = options.highlight })
-	vim.fn.sign_define("FilemarkSign", { text = options.file_sign, texthl = options.file_highlight })
+	vim.fn.sign_define("BookmarkSign", { text = M.options.sign, texthl = M.options.highlight })
+	vim.fn.sign_define("FilemarkSign", { text = M.options.file_sign, texthl = M.options.file_highlight })
 end
 
 return M


### PR DESCRIPTION
Fix #5. Use `M.options` instead of `options`